### PR TITLE
fixed: using onNewToken instead of overriding deprecated onTokenRefresh

### DIFF
--- a/src/android/MyFirebaseInstanceIDService.java
+++ b/src/android/MyFirebaseInstanceIDService.java
@@ -12,9 +12,10 @@ public class MyFirebaseInstanceIDService extends FirebaseMessagingService {
     
     private static final String TAG = "FCMPlugin";
 
+    @Override
     public void onNewToken (String newToken) {
         super.onNewToken(newToken);
-        Log.d("NEW_TOKEN", newToken);
+        Log.d(TAG, "NEW_TOKEN: " + newToken);
         FCMPlugin.sendTokenRefresh(newToken);
     }
 }

--- a/src/android/MyFirebaseInstanceIDService.java
+++ b/src/android/MyFirebaseInstanceIDService.java
@@ -1,25 +1,20 @@
 package com.gae.scaffolder.plugin;
 
 import android.util.Log;
-
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.FirebaseInstanceIdService;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingService;
 
 /**
  * Created by Felipe Echanique on 08/06/2016.
+ * Changed by Alex Barboza on 14/05/2019
  */
-public class MyFirebaseInstanceIDService extends FirebaseInstanceIdService {
-
+public class MyFirebaseInstanceIDService extends FirebaseMessagingService {
+    
     private static final String TAG = "FCMPlugin";
 
-    @Override
-    public void onTokenRefresh(){
-        // Get updated InstanceID token.
-        String refreshedToken = FirebaseInstanceId.getInstance().getToken();
-        Log.d(TAG, "Refreshed token: " + refreshedToken);
-		FCMPlugin.sendTokenRefresh( refreshedToken );
-
-        // TODO: Implement this method to send any registration to your app's servers.
-        //sendRegistrationToServer(refreshedToken);
+    public void onNewToken (String newToken) {
+        super.onNewToken(newToken);
+        Log.d("NEW_TOKEN", newToken);
+        FCMPlugin.sendTokenRefresh(newToken);
     }
 }


### PR DESCRIPTION
Please, notice that FirebaseInstanceIdService shouldn't be used anymore (https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceIdService) and, also, we should use onNewToken instead of onTokenRefresh .